### PR TITLE
Fix gocognit output when a function has generic receiver type

### DIFF
--- a/gocognit.go
+++ b/gocognit.go
@@ -49,18 +49,6 @@ func funcName(fn *ast.FuncDecl) string {
 	return fn.Name.Name
 }
 
-// recvString returns a string representation of recv of the
-// form "T", "*T", or "BADRECV" (if not a proper receiver type).
-func recvString(recv ast.Expr) string {
-	switch t := recv.(type) {
-	case *ast.Ident:
-		return t.Name
-	case *ast.StarExpr:
-		return "*" + recvString(t.X)
-	}
-	return "BADRECV"
-}
-
 // Complexity calculates the cognitive complexity of a function.
 func Complexity(fn *ast.FuncDecl) int {
 	v := complexityVisitor{

--- a/gocognit118_test.go
+++ b/gocognit118_test.go
@@ -1,0 +1,17 @@
+//go:build go1.18
+// +build go1.18
+
+package gocognit_test
+
+import (
+	"testing"
+
+	"github.com/uudashr/gocognit"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer_Generics(t *testing.T) {
+	testdata := analysistest.TestData()
+	gocognit.Analyzer.Flags.Set("over", "0")
+	analysistest.Run(t, testdata, gocognit.Analyzer, "c")
+}

--- a/recv.go
+++ b/recv.go
@@ -1,0 +1,30 @@
+//go:build go1.18
+// +build go1.18
+
+package gocognit
+
+import (
+	"go/ast"
+	"strings"
+)
+
+// recvString returns a string representation of recv of the
+// form "T", "*T", Type[T], Type[T, V], or "BADRECV" (if not a proper receiver type).
+func recvString(recv ast.Expr) string {
+	switch t := recv.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return "*" + recvString(t.X)
+	case *ast.IndexExpr:
+		return recvString(t.X) + "[" + recvString(t.Index) + "]"
+	case *ast.IndexListExpr:
+		targs := make([]string, len(t.Indices))
+		for i, exp := range t.Indices {
+			targs[i] = recvString(exp)
+		}
+
+		return recvString(t.X) + "[" + strings.Join(targs, ", ") + "]"
+	}
+	return "BADRECV"
+}

--- a/recv_pre118.go
+++ b/recv_pre118.go
@@ -1,0 +1,20 @@
+//go:build !go1.18
+// +build !go1.18
+
+package gocognit
+
+import (
+	"go/ast"
+)
+
+// recvString returns a string representation of recv of the
+// form "T", "*T", or "BADRECV" (if not a proper receiver type).
+func recvString(recv ast.Expr) string {
+	switch t := recv.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return "*" + recvString(t.X)
+	}
+	return "BADRECV"
+}

--- a/testdata/src/c/c.go
+++ b/testdata/src/c/c.go
@@ -1,0 +1,36 @@
+package testdata
+
+type Node[T any] struct {
+}
+
+func (n *Node[T]) String() string { // want "cognitive complexity 1 of func \\(\\*Node\\[T\\]\\)\\.String is high \\(> 0\\)"
+	if n != nil { // +1
+		return "Node"
+	}
+
+	return ""
+} // total complexity = 1
+
+type Pair[K any, V any] struct {
+	Key   K
+	Value V
+}
+
+func (p *Pair[K, V]) String() string { // want "cognitive complexity 1 of func \\(\\*Pair\\[K, V\\]\\)\\.String is high \\(> 0\\)"
+	if p != nil { // +1
+		return "Pair"
+	}
+
+	return ""
+} // total complexity = 1
+
+type Triple[K any, V any, T any] struct {
+}
+
+func (t *Triple[K, V, T]) String() string { // want "cognitive complexity 1 of func \\(\\*Triple\\[K, V, T\\]\\)\\.String is high \\(> 0\\)"
+	if t != nil { // +1 `
+		return "Triple"
+	}
+
+	return ""
+} // total complexity = 1


### PR DESCRIPTION
recvString func in gocognit returns BADRECV when the function's receiver is a
generic type.