### PR TITLE
Simplify recvString output

### DIFF
--- a/recv.go
+++ b/recv.go
@@ -5,11 +5,10 @@ package gocognit
 
 import (
 	"go/ast"
-	"strings"
 )
 
 // recvString returns a string representation of recv of the
-// form "T", "*T", Type[T], Type[T, V], or "BADRECV" (if not a proper receiver type).
+// form "T", "*T", or "BADRECV" (if not a proper receiver type).
 func recvString(recv ast.Expr) string {
 	switch t := recv.(type) {
 	case *ast.Ident:
@@ -17,14 +16,9 @@ func recvString(recv ast.Expr) string {
 	case *ast.StarExpr:
 		return "*" + recvString(t.X)
 	case *ast.IndexExpr:
-		return recvString(t.X) + "[" + recvString(t.Index) + "]"
+		return recvString(t.X)
 	case *ast.IndexListExpr:
-		targs := make([]string, len(t.Indices))
-		for i, exp := range t.Indices {
-			targs[i] = recvString(exp)
-		}
-
-		return recvString(t.X) + "[" + strings.Join(targs, ", ") + "]"
+		return recvString(t.X)
 	}
 	return "BADRECV"
 }

--- a/testdata/src/c/c.go
+++ b/testdata/src/c/c.go
@@ -3,7 +3,7 @@ package testdata
 type Node[T any] struct {
 }
 
-func (n *Node[T]) String() string { // want "cognitive complexity 1 of func \\(\\*Node\\[T\\]\\)\\.String is high \\(> 0\\)"
+func (n *Node[T]) String() string { // want "cognitive complexity 1 of func \\(\\*Node\\)\\.String is high \\(> 0\\)"
 	if n != nil { // +1
 		return "Node"
 	}
@@ -16,7 +16,7 @@ type Pair[K any, V any] struct {
 	Value V
 }
 
-func (p *Pair[K, V]) String() string { // want "cognitive complexity 1 of func \\(\\*Pair\\[K, V\\]\\)\\.String is high \\(> 0\\)"
+func (p *Pair[K, V]) String() string { // want "cognitive complexity 1 of func \\(\\*Pair\\)\\.String is high \\(> 0\\)"
 	if p != nil { // +1
 		return "Pair"
 	}
@@ -27,7 +27,7 @@ func (p *Pair[K, V]) String() string { // want "cognitive complexity 1 of func \
 type Triple[K any, V any, T any] struct {
 }
 
-func (t *Triple[K, V, T]) String() string { // want "cognitive complexity 1 of func \\(\\*Triple\\[K, V, T\\]\\)\\.String is high \\(> 0\\)"
+func (t *Triple[K, V, T]) String() string { // want "cognitive complexity 1 of func \\(\\*Triple\\)\\.String is high \\(> 0\\)"
 	if t != nil { // +1 `
 		return "Triple"
 	}


### PR DESCRIPTION
Refactor recvString to return only type's name without it's type
parameters when the type is generic.

In this way type's string representation will be consistent with
function's string representation(gocognit print only function's name
even if it's generic one).