### PR TITLE
Run test against go 1.20 and 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         os-version: ['stable']
-        go-version: ['1.16', '1.17', '1.18', '1.19']
+        go-version: ['1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Changes
- CI add checks against up to go version 1.21